### PR TITLE
Job Per Project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,8 @@ jobs:
     <<: *defaults
     working_directory: ~/monorepo-builds/project_a
     steps:
-      - checkout: ~/monorepo-builds
+      - checkout:
+          path: ~/monorepo-builds
       - run:
           name: Install dependencies
           command: echo "install"
@@ -94,7 +95,8 @@ jobs:
     <<: *defaults
     working_directory: ~/monorepo-builds/project_b
     steps:
-      - checkout: ~/monorepo-builds
+      - checkout:
+          path: ~/monorepo-builds
       - run:
           name: Install dependencies
           command: echo "install"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ defaults: &defaults
 jobs:
   clone_and_hash:
     <<: *defaults
-
     steps:
       - checkout
       - restore_cache:
@@ -17,7 +16,7 @@ jobs:
             - v1-project-hashes-master
 
       - run:
-          name: Copy old hashes to workspace
+          name: Copy old hashes to shared workspace
           command: |
             mkdir -p .project-hashes
             cp .project-a-hash .project-hashes
@@ -29,40 +28,33 @@ jobs:
             git log --pretty=format:'%H' -n 1 -- project_a > .project-hashes/.project-a-hash.new
             git log --pretty=format:'%H' -n 1 -- project_b > .project-hashes/.project-b-hash.new
 
+      - run:
+          name: Determine Changed Projects
+          command: |
+            if ! diff .project-hashes/.project-a-hash{,.new} > /dev/null; then
+              touch .project-hashes/.project-a-changed
+            fi
+
+            if ! diff .project-hashes/.project-b-hash{,.new} > /dev/null; then
+              touch .project-hashes/.project-b-changed
+            fi
+
+      - run:
+          name: Set current project hashes
+          command: |
+            mv .project-hashes/.project-a-hash{.new,}
+            mv .project-hashes/.project-b-hash{.new,}
+
       - persist_to_workspace:
           root: .
           paths:
             - .project-hashes
 
-  project_a_changed:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: .
-      - run: "! diff .project-hashes/.project-a-hash{,.new}"
-
-  project_b_changed:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: .
-      - run: "! diff .project-hashes/.project-b-hash{,.new}"
-
-  save_hashes:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name:
-          command: |
-            cp .project-hashes/.project-a-hash.new .project-a-hash
-            cp .project-hashes/.project-b-hash.new .project-b-hash
       - save_cache:
           key: v1-project-hashes-{{ .Branch }}-{{ epoch }}
           paths:
-            - .project-a-hash
-            - .project-b-hash
+            - .project-hashes/.project-a-hash
+            - .project-hashes/.project-b-hash
 
   project_a:
     <<: *defaults
@@ -120,18 +112,9 @@ workflows:
   build_test_deploy:
     jobs:
       - clone_and_hash
-      - save_hashes:
-          requires:
-            - clone_and_hash
-      - project_a_changed:
-          requires:
-            - clone_and_hash
-      - project_b_changed:
-          requires:
-            - clone_and_hash
       - project_a:
           requires:
-            - project_a_changed
+            - clone_and_hash
       - project_b:
           requires:
-            - project_b_changed
+            - clone_and_hash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,49 +12,49 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-project-hashes-{{ .Branch }}
-            - v1-project-hashes-master
+            - v1-project-metadata-{{ .Branch }}
+            - v1-project-metadata-master
 
       - run:
           name: Copy old hashes to shared workspace
           command: |
-            mkdir -p .project-hashes
-            cp .project-a-hash .project-hashes
-            cp .project-b-hash .project-hashes
+            mkdir -p .project-metadata
+            cp .project-a-hash .project-metadata
+            cp .project-b-hash .project-metadata
 
       - run:
           name: Hash Projects
           command: |
-            git log --pretty=format:'%H' -n 1 -- project_a > .project-hashes/.project-a-hash.new
-            git log --pretty=format:'%H' -n 1 -- project_b > .project-hashes/.project-b-hash.new
+            git log --pretty=format:'%H' -n 1 -- project_a > .project-metadata/.project-a-hash.new
+            git log --pretty=format:'%H' -n 1 -- project_b > .project-metadata/.project-b-hash.new
 
       - run:
           name: Determine Changed Projects
           command: |
-            if ! diff .project-hashes/.project-a-hash{,.new} > /dev/null; then
-              touch .project-hashes/.project-a-changed
+            if ! diff .project-metadata/.project-a-hash{,.new} > /dev/null; then
+              touch .project-metadata/.project-a-changed
             fi
 
-            if ! diff .project-hashes/.project-b-hash{,.new} > /dev/null; then
-              touch .project-hashes/.project-b-changed
+            if ! diff .project-metadata/.project-b-hash{,.new} > /dev/null; then
+              touch .project-metadata/.project-b-changed
             fi
 
       - run:
           name: Set current project hashes
           command: |
-            mv .project-hashes/.project-a-hash{.new,}
-            mv .project-hashes/.project-b-hash{.new,}
+            mv .project-metadata/.project-a-hash{.new,}
+            mv .project-metadata/.project-b-hash{.new,}
 
       - persist_to_workspace:
           root: .
           paths:
-            - .project-hashes
+            - .project-metadata
 
       - save_cache:
-          key: v1-project-hashes-{{ .Branch }}-{{ epoch }}
+          key: v1-project-metadata-{{ .Branch }}-{{ epoch }}
           paths:
-            - .project-hashes/.project-a-hash
-            - .project-hashes/.project-b-hash
+            - .project-metadata/.project-a-hash
+            - .project-metadata/.project-b-hash
 
   project_a:
     <<: *defaults
@@ -65,7 +65,7 @@ jobs:
       - run:
           name: Check if project changed
           command: |
-            if [ -e .project-hashes/.project-a-changed ]; then
+            if [ -e .project-metadata/.project-a-changed ]; then
               echo "let's do this"
             else
               echo "nothing to do"
@@ -99,7 +99,7 @@ jobs:
       - run:
           name: Check if project changed
           command: |
-            if [ -e .project-hashes/.project-b-changed ]; then
+            if [ -e .project-metadata/.project-b-changed ]; then
               echo "let's do this"
             else
               echo "nothing to do"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,14 +39,14 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: ! diff .project-hashes/.project-a-hash{,.new}
+      - run: "! diff .project-hashes/.project-a-hash{,.new}"
 
   project_b_changed:
     <<: *defaults
     steps:
       - attach_workspace:
           at: .
-      - run: ! diff .project-hashes/.project-b-hash{,.new}
+      - run: "! diff .project-hashes/.project-b-hash{,.new}"
 
   save_hashes:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,11 @@ jobs:
       - run:
           name: Determine changed projects
           command: |
-            if ! diff .project-metadata/.project-a-hash{,.new} > /dev/null; then
+            if ! diff .project-metadata/.project-a-hash{,.new}; then
               touch .project-metadata/.project-a-changed
             fi
 
-            if ! diff .project-metadata/.project-b-hash{,.new} > /dev/null; then
+            if ! diff .project-metadata/.project-b-hash{,.new}; then
               touch .project-metadata/.project-b-changed
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: Copy old hashes to shared workspace
           command: |
             mkdir -p .project-metadata
-            ls -al .project-metadata
+            touch .project-{a,b}-hash
             cp .project-a-hash .project-metadata
             cp .project-b-hash .project-metadata
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,15 @@ jobs:
     steps:
       - checkout: { path: ~/monorepo-builds }
       - attach_workspace: { at: . }
-      - run: ls -al
-      - run: ls -al .project-hashes
+      - run:
+          name: Check if project changed
+          command: |
+            if [ -e .project-hashes/.project-a-changed ]; then
+              echo "let's do this"
+            else
+              echo "nothing to do"
+            fi
+
       - run:
           name: Install dependencies
           command: echo "install"
@@ -89,8 +96,15 @@ jobs:
     steps:
       - checkout: { path: ~/monorepo-builds }
       - attach_workspace: { at: . }
-      - run: ls -al
-      - run: ls -al .project-hashes
+      - run:
+          name: Check if project changed
+          command: |
+            if [ -e .project-hashes/.project-b-changed ]; then
+              echo "let's do this"
+            else
+              echo "nothing to do"
+            fi
+
       - run:
           name: Install dependencies
           command: echo "install"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ jobs:
             - .project-b-hash
 
   project_a:
+    <<: *defaults
     working_directory: ~/monorepo-builds/project_a
     steps:
       - checkout: ~/monorepo-builds
@@ -86,6 +87,7 @@ jobs:
             fi
 
   project_b:
+    <<: *defaults
     working_directory: ~/monorepo-builds/project_b
     steps:
       - checkout: ~/monorepo-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,80 +1,131 @@
 version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/node:8.2.1
 
-    working_directory: ~/monorepo-builds
+defaults: &defaults
+  docker:
+    - image: circleci/node:8.2.1
+  working_directory: ~/monorepo-builds
+
+jobs:
+  clone_and_hash:
+    <<: *defaults
 
     steps:
       - checkout
-
-      - run:
-          name: Hash Projects
-          command: |
-            git log --pretty=format:'%H' -n 1 -- project_a > .project-a-hash.new
-            git log --pretty=format:'%H' -n 1 -- project_b > .project-b-hash.new
-
       - restore_cache:
           keys:
             - v1-project-hashes-{{ .Branch }}
             - v1-project-hashes-master
 
       - run:
-          name: Build modified Projects
+          name: Copy old hashes to workspace
           command: |
-            if diff .project-a-hash{,.new} > /dev/null; then
-              echo "Project A won't be built"
-            else
-              echo "Building Project A"
-            fi
+            cp .project-a-hash .project-hashes
+            cp .project-b-hash .project-hashes
 
-            if diff .project-b-hash{,.new} > /dev/null; then
-              echo "Project B won't be built"
-            else
-              echo "Building Project B"
-            fi
+      - run:
+          name: Hash Projects
+          command: |
+            git log --pretty=format:'%H' -n 1 -- project_a > .project-hashes/.project-a-hash.new
+            git log --pretty=format:'%H' -n 1 -- project_b > .project-hashes/.project-b-hash.new
+
+      - persist_to_workspace:
+          paths:
+            - .project-hashes
+
+  project_a_changed:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run: diff .project-hashes/project-a-hash{,.new}
+
+  project_b_changed:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run: diff .project-hashes/project-b-hash{,.new}
+
+  save_hashes:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name:
+          command: |
+            cp .project-hashes/.project-a-hash.new .project-a-hash
+            cp .project-hashes/.project-b-hash.new .project-b-hash
+      - save_cache:
+          key: v1-project-hashes-{{ .Branch }}-{{ epoch }}
+          paths:
+            - .project-a-hash
+            - .project-b-hash
+
+  project_a:
+    working_directory: ~/monorepo-builds/project_a
+    steps:
+      - checkout: ~/monorepo-builds
+      - run:
+          name: Install dependencies
+          command: echo "install"
+
+      - run:
+          name: Build modified Projects
+          command: echo "Building Project A"
 
       - run:
           name: Test modified Projects
-          command: |
-            if diff .project-a-hash{,.new} > /dev/null; then
-              echo "Project A won't be tested"
-            else
-              echo "Testing Project A"
-            fi
-
-            if diff .project-b-hash{,.new} > /dev/null; then
-              echo "Project B won't be tested"
-            else
-              echo "Testing Project B"
-            fi
+          command: echo "Testing Project A"
 
       - run:
           name: Deployment
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              if diff .project-a-hash{,.new} > /dev/null; then
-                echo "Project A won't be deployed"
-              else
-                echo "Deploying Project A"
-              fi
-
-              if diff .project-b-hash{,.new} > /dev/null; then
-                echo "Project B won't be deployed"
-              else
-                echo "Deploying Project B"
-              fi
+              echo "Deploying Project A"
             fi
 
+  project_b:
+    working_directory: ~/monorepo-builds/project_b
+    steps:
+      - checkout: ~/monorepo-builds
       - run:
-          name: Set new project hashes
-          command: |
-            mv .project-a-hash{.new,}
-            mv .project-b-hash{.new,}
+          name: Install dependencies
+          command: echo "install"
 
-      - save_cache:
-          paths:
-            - .project-a-hash
-            - .project-b-hash
-          key: v1-project-hashes-{{ .Branch }}-{{ epoch }}
+      - run:
+          name: Build modified Projects
+          command: echo "Building Project B"
+
+      - run:
+          name: Test modified Projects
+          command: echo "Testing Project B"
+
+      - run:
+          name: Deployment
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              echo "Deploying Project B"
+            fi
+
+workflows:
+  version: 2
+
+  build_test_deploy:
+    jobs:
+      - clone_and_hash
+      - save_hashes:
+          requires:
+            - clone_and_hash
+      - project_a_changed:
+          requires:
+            - clone_and_hash
+      - project_b_changed:
+          requires:
+            - clone_and_hash
+      - project_a:
+          requires:
+            - project_a_changed
+      - project_b:
+          requires:
+            - project_b_changed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,8 @@ jobs:
     <<: *defaults
     working_directory: ~/monorepo-builds/project_a
     steps:
-      - checkout:
-          path: ~/monorepo-builds
+      - checkout: { path: ~/monorepo-builds }
+      - attach_workspace: { at: . }
       - run:
           name: Install dependencies
           command: echo "install"
@@ -85,8 +85,8 @@ jobs:
     <<: *defaults
     working_directory: ~/monorepo-builds/project_b
     steps:
-      - checkout:
-          path: ~/monorepo-builds
+      - checkout: { path: ~/monorepo-builds }
+      - attach_workspace: { at: . }
       - run:
           name: Install dependencies
           command: echo "install"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - run: ls -al
       - run: diff .project-hashes/project-a-hash{,.new}
 
   project_b_changed:
@@ -46,6 +47,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - run: ls -al
       - run: diff .project-hashes/project-b-hash{,.new}
 
   save_hashes:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,11 +75,11 @@ jobs:
           command: echo "install"
 
       - run:
-          name: Build modified Projects
+          name: Build
           command: echo "Building Project A"
 
       - run:
-          name: Test modified Projects
+          name: Test
           command: echo "Testing Project A"
 
       - run:
@@ -100,11 +100,11 @@ jobs:
           command: echo "install"
 
       - run:
-          name: Build modified Projects
+          name: Build
           command: echo "Building Project B"
 
       - run:
-          name: Test modified Projects
+          name: Test
           command: echo "Testing Project B"
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,13 @@ jobs:
             cp .project-b-hash .project-metadata
 
       - run:
-          name: Hash Projects
+          name: Hash projects
           command: |
             git log --pretty=format:'%H' -n 1 -- project_a > .project-metadata/.project-a-hash.new
             git log --pretty=format:'%H' -n 1 -- project_b > .project-metadata/.project-b-hash.new
 
       - run:
-          name: Determine Changed Projects
+          name: Determine changed projects
           command: |
             if ! diff .project-metadata/.project-a-hash{,.new} > /dev/null; then
               touch .project-metadata/.project-a-changed
@@ -64,7 +64,7 @@ jobs:
       - checkout: { path: ~/monorepo-builds }
       - attach_workspace: { at: . }
       - run:
-          name: Check if project changed
+          name: Check whether project changed
           command: |
             if [ -e .project-metadata/.project-a-changed ]; then
               echo "let's do this"
@@ -98,7 +98,7 @@ jobs:
       - checkout: { path: ~/monorepo-builds }
       - attach_workspace: { at: . }
       - run:
-          name: Check if project changed
+          name: Check whether project changed
           command: |
             if [ -e .project-metadata/.project-b-changed ]; then
               echo "let's do this"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,35 +16,33 @@ jobs:
             - v1-project-metadata-master
 
       - run:
-          name: Copy old hashes to shared workspace
+          name: Initialize project metadata
           command: |
             mkdir -p .project-metadata
             touch .project-{a,b}-hash
-            cp .project-a-hash .project-metadata
-            cp .project-b-hash .project-metadata
 
       - run:
           name: Hash projects
           command: |
-            git log --pretty=format:'%H' -n 1 -- project_a > .project-metadata/.project-a-hash.new
-            git log --pretty=format:'%H' -n 1 -- project_b > .project-metadata/.project-b-hash.new
+            git log --pretty=format:'%H' -n 1 -- project_a > .project-a-hash.new
+            git log --pretty=format:'%H' -n 1 -- project_b > .project-b-hash.new
 
       - run:
           name: Determine changed projects
           command: |
-            if ! diff .project-metadata/.project-a-hash{,.new}; then
+            if ! diff .project-a-hash{,.new} > /dev/null; then
               touch .project-metadata/.project-a-changed
             fi
 
-            if ! diff .project-metadata/.project-b-hash{,.new}; then
+            if ! diff .project-b-hash{,.new} > /dev/null; then
               touch .project-metadata/.project-b-changed
             fi
 
       - run:
           name: Set current project hashes
           command: |
-            mv .project-metadata/.project-a-hash{.new,}
-            mv .project-metadata/.project-b-hash{.new,}
+            mv .project-a-hash{.new,}
+            mv .project-b-hash{.new,}
 
       - persist_to_workspace:
           root: .
@@ -54,8 +52,8 @@ jobs:
       - save_cache:
           key: v1-project-metadata-{{ .Branch }}-{{ epoch }}
           paths:
-            - .project-metadata/.project-a-hash
-            - .project-metadata/.project-b-hash
+            - .project-a-hash
+            - .project-b-hash
 
   project_a:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: ls -al
-      - run: diff .project-hashes/project-a-hash{,.new}
+      - run: diff .project-hashes/.project-a-hash{,.new}
 
   project_b_changed:
     <<: *defaults
@@ -48,7 +48,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: ls -al
-      - run: diff .project-hashes/project-b-hash{,.new}
+      - run: diff .project-hashes/.project-b-hash{,.new}
 
   save_hashes:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,8 @@ jobs:
     steps:
       - checkout: { path: ~/monorepo-builds }
       - attach_workspace: { at: . }
+      - run: ls -al
+      - run: ls -al .project-hashes
       - run:
           name: Install dependencies
           command: echo "install"
@@ -87,6 +89,8 @@ jobs:
     steps:
       - checkout: { path: ~/monorepo-builds }
       - attach_workspace: { at: . }
+      - run: ls -al
+      - run: ls -al .project-hashes
       - run:
           name: Install dependencies
           command: echo "install"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
             git log --pretty=format:'%H' -n 1 -- project_b > .project-hashes/.project-b-hash.new
 
       - persist_to_workspace:
+          root: .
           paths:
             - .project-hashes
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
       - run:
           name: Copy old hashes to workspace
           command: |
+            mkdir -p .project-hashes
             cp .project-a-hash .project-hashes
             cp .project-b-hash .project-hashes
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
           name: Copy old hashes to shared workspace
           command: |
             mkdir -p .project-metadata
+            ls -al .project-metadata
             cp .project-a-hash .project-metadata
             cp .project-b-hash .project-metadata
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,16 +39,14 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: ls -al
-      - run: diff .project-hashes/.project-a-hash{,.new}
+      - run: ! diff .project-hashes/.project-a-hash{,.new}
 
   project_b_changed:
     <<: *defaults
     steps:
       - attach_workspace:
           at: .
-      - run: ls -al
-      - run: diff .project-hashes/.project-b-hash{,.new}
+      - run: ! diff .project-hashes/.project-b-hash{,.new}
 
   save_hashes:
     <<: *defaults


### PR DESCRIPTION
This adds a working proof of concept that examines the codebase, builds metadata indicating which projects have changed since the last run, and passes that information to downstream builds to aid in their decision making.

Leaving all the messy commits in here because they might prove useful to posterity.

I added the [optional-jobs](https://github.com/rylnd/monorepo-builds/tree/optional-jobs) tag that is a little nicer/cleaner/clearer, where determination of project changes is done in an upstream job, but that work requires Circle's support of optional jobs.